### PR TITLE
Update pokemon data source to GitHub raw URLs

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -8,7 +8,7 @@ import styles from "../styles/Home.module.css";
 // export async function getServerSideProps() { // Server side rendering
 export async function getStaticProps() { // Change to Static Site Generation (SSG)
     const resp = await fetch(
-        "https://jherr-pokemon.s3.us-west-1.amazonaws.com/index.json"
+        "https://raw.githubusercontent.com/edisplay/pokemon/main/index.json"
     );
   return {
     props: {
@@ -25,7 +25,7 @@ export default function Home({pokemon}) { // Server-side rendering
     useEffect(() => {
         async function getPokemon() {
             const resp = await fetch(
-                "https://jherr-pokemon.s3.us-west-1.amazonaws.com/index.json"
+                "https://raw.githubusercontent.com/edisplay/pokemon/main/index.json"
             );
             setPokemon(await resp.json());
         }
@@ -44,7 +44,7 @@ export default function Home({pokemon}) { // Server-side rendering
                         <Link href={`/pokemon/${pokemon.id}`}>
                             <a>
                                 <img
-                                    src={`https://jherr-pokemon.s3.us-west-1.amazonaws.com/${pokemon.image}`}
+                                    src={`https://raw.githubusercontent.com/edisplay/pokemon/main/${pokemon.image}`}
                                     alt={pokemon.name}
                                 />
                                 <h3>{pokemon.name}</h3>

--- a/pages/pokemon/[id].js
+++ b/pages/pokemon/[id].js
@@ -11,7 +11,7 @@ import styles from "../../styles/Details.module.css";
 // Static Site Generation (SSG) - Know what all the routes are
 export async function getStaticPaths() {
     const resp = await fetch(
-        "https://jherr-pokemon.s3.us-west-1.amazonaws.com/index.json"
+        "https://raw.githubusercontent.com/edisplay/pokemon/main/index.json"
     );
     const pokemon = await resp.json();
     return {
@@ -26,7 +26,7 @@ export async function getStaticPaths() {
 // export async function getServerSideProps({ params }) { // Server side rendering
 export async function getStaticProps({ params }) { // Change to Static Site Generation (SSG)
     const resp = await fetch(
-        `https://jherr-pokemon.s3.us-west-1.amazonaws.com/pokemon/${params.id}.json`
+        `https://raw.githubusercontent.com/edisplay/pokemon/main/pokemon/${params.id}.json`
     );
     return {
         props: {
@@ -47,7 +47,7 @@ export default function Details({ pokemon }) {
     useEffect(() => {
         async function getPokemon() {
             const resp = await fetch(
-                `https://jherr-pokemon.s3.us-west-1.amazonaws.com/pokemon/${id}.json`
+                `https://raw.githubusercontent.com/edisplay/pokemon/main/pokemon/${id}.json`
             );
             setPokemon(await resp.json());
         }
@@ -74,7 +74,7 @@ export default function Details({ pokemon }) {
                 <div>
                     <img
                         className={styles.picture}
-                        src={`https://jherr-pokemon.s3.us-west-1.amazonaws.com/${pokemon.image}`}
+                        src={`https://raw.githubusercontent.com/edisplay/pokemon/main/${pokemon.image}`}
                         alt={pokemon.name.english}
                     />
                 </div>


### PR DESCRIPTION
## Problem
The app currently relies on the jherr-pokemon S3 bucket for all pokemon data and images. This creates an external dependency that's not under our control.

## Solution
Migrate all data sources to use the [edisplay/pokemon](https://github.com/edisplay/pokemon) repository via GitHub raw content URLs. This ensures data consistency and eliminates the S3 dependency.

## Changes
- Updated index.json fetch endpoints in both home and detail pages
- Updated pokemon detail JSON fetch endpoints
- Updated pokemon image URLs to use GitHub raw content delivery

All URLs now point to `https://raw.githubusercontent.com/edisplay/pokemon/main/` ensuring the app uses the authoritative pokemon data repository.

## Summary by Sourcery

Update the application to load Pokémon data and images from the GitHub-hosted edisplay/pokemon repository instead of the previous S3 bucket.

Enhancements:
- Switch all Pokémon JSON data fetches to use GitHub raw content URLs.
- Update Pokémon image URLs to point to the GitHub raw content repository.